### PR TITLE
Replacing seth's repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.12
 futures==3.0.5
 jmespath==0.9.0
 python-dateutil==2.5.3
-PyYAML==5.1
+PyYAML==5.4
 requests==2.24.0
 s3transfer==0.1.2
 six==1.10.0


### PR DESCRIPTION
There was just a change in version number that was requested by the dependabot. This pull request is to catch it up with what we are currently using and swap off of that and to our own. Seth's repo is now archived so there will be no more updates and this will remove that dependability. 